### PR TITLE
skip Launch Preview Confirmation box

### DIFF
--- a/SQL2/MainWindow.xaml.cs
+++ b/SQL2/MainWindow.xaml.cs
@@ -512,7 +512,7 @@ namespace mxd.SQL2
 
 #if DEBUG
 			string result = engine.FileName + " " + argsstr;
-			if(MessageBox.Show(this, "Launch parameters:\n" + result + "\n\nProceed?", "Launch Preview", MessageBoxButton.YesNo) == MessageBoxResult.No) return;
+			//if(MessageBox.Show(this, "Launch parameters:\n" + result + "\n\nProceed?", "Launch Preview", MessageBoxButton.YesNo) == MessageBoxResult.No) return;
 #endif
 
 			// Setup process info


### PR DESCRIPTION
# Description
Skips over the **Launch Preview Confirmation** text box that appears after pressing `Launch`

## Type of change
- [x] User Interface Change fix (non-breaking change which fixes an aesthetic issue)

# Testing Instructions
- build 
- drop in Quake or Quake 2 directory
-  launch Game (no dialog box after launch button is pressed.)

# Checklist:
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works